### PR TITLE
feat: Alert when PW change is required on login

### DIFF
--- a/ku-boost-iOS/Data/MyError.swift
+++ b/ku-boost-iOS/Data/MyError.swift
@@ -5,7 +5,7 @@
 //  Created by 승윤이 on 2021/02/16.
 //
 
-public enum MyError: Error {
+public enum MyError: Error, Equatable {
 
   // MARK: - Internal errors
   case noInternet

--- a/ku-boost-iOS/ViewModels/ChangePasswordViewModel.swift
+++ b/ku-boost-iOS/ViewModels/ChangePasswordViewModel.swift
@@ -40,7 +40,7 @@ class ChangePasswordViewModel: ObservableObject, Identifiable {
   func changePassword() {
     firstly{
       authRepo.makeChangePasswordRequest(
-        username: UserDefaults.standard.string(forKey: "id")!,
+        username: UserDefaults.id,
         before: bfPassword,
         after: afPassword1)
     }.done{

--- a/ku-boost-iOS/ViewModels/LoginViewModel.swift
+++ b/ku-boost-iOS/ViewModels/LoginViewModel.swift
@@ -33,6 +33,7 @@ class LoginViewModel: ObservableObject, Identifiable {
 
   @Published var errMsg = ""
   @Published var gotError = false
+  @Published var error: MyError? = nil
 
   var authRepo = AuthRepository.shared
   var keyChain = KeyChain.shared
@@ -68,12 +69,27 @@ class LoginViewModel: ObservableObject, Identifiable {
         } else {
           self.errMsg = "네트워크 연결이 없습니다."
         }
-      //TODO: change pw or change after 90 days
+      case .changePwRequired:
+        UserDefaults.id = self.username
+        self.errMsg = "비밀번호를 변경한지 90일이 지났습니다."
       default:
         print("error : \(error)")
         self.errMsg = "알수없는 오류\n관리자에게 문의 바랍니다."
       }
       self.gotError = true
+      self.error = error
+    }
+  }
+
+  func changeAfter90Days() {
+    isLoading = true
+    firstly{
+      authRepo.makeChangePasswordRequest(username: username, password: password)
+    }.done{
+      self.isLoading = false
+      print("after 90 done")
+    }.catch{ err in
+      print(err)
     }
   }
 

--- a/ku-boost-iOS/Views/LoginView.swift
+++ b/ku-boost-iOS/Views/LoginView.swift
@@ -14,6 +14,7 @@ struct LoginView: View {
   // MARK: Internal
 
   @ObservedObject var viewModel = LoginViewModel.shared
+  @State var changePW = false
 
   var loginButton: some View {
     NavigationLink(
@@ -36,7 +37,22 @@ struct LoginView: View {
       self.loginUser()
     })
       .alert(isPresented: $viewModel.gotError) {
-        Alert(title: Text("오류"), message: Text("\(viewModel.errMsg)"))
+        if viewModel.error == .changePwRequired {
+          return Alert(
+            title: Text("오류"),
+            message: Text("\(viewModel.errMsg)"),
+            primaryButton: .default(
+              Text("90일뒤 변경"),
+              action: {
+                viewModel.changeAfter90Days()
+              }),
+            secondaryButton:.default(
+              Text("비밀번호 변경"), action: {
+                changePW = true
+              }))
+        } else {
+          return Alert(title: Text("오류"), message: Text("\(viewModel.errMsg)"))
+        }
       }
   }
 
@@ -64,14 +80,22 @@ struct LoginView: View {
   var body: some View {
     NavigationView {
       LoadingView(isShowing: .constant(viewModel.isLoading)) {
-        VStack(alignment: .center) {
-          self.titleView
-          self.placeHolderTextView
-          self.passwordTextView
-          self.loginButton
-          Spacer()
-          Spacer()
-        }.padding(22.0)
+        ZStack{
+          VStack(alignment: .center) {
+            self.titleView
+            self.placeHolderTextView
+            self.passwordTextView
+            self.loginButton
+            Spacer()
+            Spacer()
+          }.padding(22.0)
+          NavigationLink(
+            destination: ChangePasswordView(),
+            isActive: $changePW,
+            label: {
+              EmptyView()
+            })
+        }
       }
     }
 


### PR DESCRIPTION
When server responded that user need to change password, app will alert and user can choose between 'change after 90 days' or 'change password'.
If user choose to change password then it will navigate to change password view.

<img src="https://user-images.githubusercontent.com/18005062/110008295-e9552000-7d5e-11eb-91ef-b8a95cf5233b.png" width="40%">
